### PR TITLE
Fix stratification by screening result

### DIFF
--- a/src/vivarium_csu_swissre_breast_cancer/components/observers.py
+++ b/src/vivarium_csu_swissre_breast_cancer/components/observers.py
@@ -153,7 +153,7 @@ class ResultsStratifier:
                     else:
                         pop_in_group = pop.loc[(stratification_group == stratification_key)
                                                & (screening_result == screening_state_name)]
-                    yield (stratification_key,), pop_in_group
+                    yield (f'{stratification_key}_screening_result_{screening_state_name}',), pop_in_group
             else:
                 stratification_key = self.get_stratification_key(stratification)
                 if pop.empty:

--- a/src/vivarium_csu_swissre_breast_cancer/globals.py
+++ b/src/vivarium_csu_swissre_breast_cancer/globals.py
@@ -295,8 +295,7 @@ STANDARD_COLUMNS = {
 THROWAWAY_COLUMNS = [f'{state}_event_count' for state in STATES]
 
 TOTAL_POPULATION_COLUMN_TEMPLATE = 'total_population_{POP_STATE}'
-PERSON_TIME_COLUMN_TEMPLATE = ('person_time_in_{YEAR}_among_{SEX}_age_cohort_{AGE_COHORT}_family_history_{HISTORY}'
-                               '_screening_result_{SCREENING_STATE}')
+PERSON_TIME_COLUMN_TEMPLATE = 'person_time_in_{YEAR}_among_{SEX}_age_cohort_{AGE_COHORT}_family_history_{HISTORY}'
 DEATH_COLUMN_TEMPLATE = ('death_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_age_cohort_{AGE_COHORT}'
                          '_family_history_{HISTORY}_screening_result_{SCREENING_STATE}')
 YLLS_COLUMN_TEMPLATE = ('ylls_due_to_{CAUSE_OF_DEATH}_in_{YEAR}_among_{SEX}_age_cohort_{AGE_COHORT}'

--- a/src/vivarium_csu_swissre_breast_cancer/results_processing/process_results.py
+++ b/src/vivarium_csu_swissre_breast_cancer/results_processing/process_results.py
@@ -29,7 +29,7 @@ OUTPUT_COLUMN_SORT_ORDER = [
 def make_measure_data(data):
     measure_data = MeasureData(
         population=get_population_data(data),
-        person_time=get_measure_data(data, 'person_time', True),
+        person_time=get_measure_data(data, 'person_time'),
         ylls=get_by_cause_measure_data(data, 'ylls', True),
         ylds=get_by_cause_measure_data(data, 'ylds'),
         deaths=get_by_cause_measure_data(data, 'deaths', True),


### PR DESCRIPTION
Fixed the bugs in the disease and mortality observers which are stratifying by screening result. 

Tested by verifying on a single simulate run call that the anomalous numbers from the previous full model run no longer appears.